### PR TITLE
Filter out referat_endret; Add mock api calls;

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,5 @@ Mikrofrontend for Dialogmøter. Appen blir lastet opp til nav sin CDN ved push t
 1. Bygg: npm run build
 2. Start: npm run dev
 3. Appen nås på http://localhost:3000
+
+For å teste i browser, kan det legges møtehistorikk i [handlers.ts](src/mocks/handlers.ts)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -18,9 +18,9 @@ function App() {
   if (motebehovResponse.error) throw motebehovResponse.error;
 
   if (dialogmoteResponse.data && dialogmoteResponse.data.length > 0) {
-    const brevArraySorted = dialogmoteResponse.data.sort(
-      (a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf()
-    );
+    const brevArraySorted = dialogmoteResponse.data
+      .filter((brev) => brev.brevType !== "REFERAT_ENDRET")
+      .sort((a, b) => new Date(b.createdAt).valueOf() - new Date(a.createdAt).valueOf());
     const latestBrev = brevArraySorted[0];
 
     if (latestBrev.brevType === "INNKALT" || latestBrev.brevType === "NYTT_TID_STED") {

--- a/src/mocks/fixtures/factories/brev.ts
+++ b/src/mocks/fixtures/factories/brev.ts
@@ -12,15 +12,17 @@ export const createDocumentComponent = (props?: Partial<BrevDocumentComponentDTO
 };
 
 export const createInnkallingsBrev = (props?: Partial<BrevDTO>): BrevDTO => {
+  const defaultDate = leggTilDagerPaDato(new Date(), -7).toISOString();
+
   return {
     uuid: "brev_uuid",
     deltakerUuid: "deltaker_uuid",
-    createdAt: leggTilDagerPaDato(new Date(), -7).toISOString(),
+    createdAt: props?.createdAt || defaultDate,
     brevType: "INNKALT",
     digitalt: true,
     fritekst: "Her kommer det en fritekst",
     sted: "sted-felt",
-    tid: leggTilDagerPaDato(new Date(), -7).toISOString(),
+    tid: props?.createdAt || defaultDate,
     videoLink: "videolenke-felt",
     document: [createDocumentComponent(), createDocumentComponent()],
     virksomhetsnummer: "virksomhetsnummer-felt",
@@ -45,11 +47,27 @@ export const createAvlysningsBrev = (props?: Partial<BrevDTO>): BrevDTO => {
 };
 
 export const createReferatBrev = (props?: Partial<BrevDTO>): BrevDTO => {
+  const defaultDate = leggTilDagerPaDato(new Date(), -67).toISOString();
+  const defaultDate2 = leggTilDagerPaDato(new Date(), -77).toISOString();
+
   return {
     ...createInnkallingsBrev(),
     brevType: "REFERAT",
-    createdAt: leggTilDagerPaDato(new Date(), -67).toISOString(),
-    tid: leggTilDagerPaDato(new Date(), -77).toISOString(),
+    createdAt: props?.createdAt || defaultDate,
+    tid: props?.createdAt || defaultDate2,
+    ...props,
+  };
+};
+
+export const createReferatEndretBrev = (props?: Partial<BrevDTO>): BrevDTO => {
+  const defaultDate = leggTilDagerPaDato(new Date(), -87).toISOString();
+  const defaultDate2 = leggTilDagerPaDato(new Date(), -97).toISOString();
+
+  return {
+    ...createInnkallingsBrev(),
+    brevType: "REFERAT_ENDRET",
+    createdAt: props?.createdAt || defaultDate,
+    tid: props?.createdAt || defaultDate2,
     ...props,
   };
 };

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -1,10 +1,22 @@
 import { http, HttpResponse } from "msw";
 import { motebehovUtenSvar } from "./fixtures/dialogmote/motebehovUtenSvar";
-import { createInnkallingsBrev } from "./fixtures/factories/brev";
+import {
+  createAvlysningsBrev,
+  createInnkallingsBrev,
+  createReferatBrev,
+  createReferatEndretBrev,
+} from "./fixtures/factories/brev";
+import { leggTilDagerPaDato } from "../utils/dateUtils";
 
 export const handlers = [
   http.get("api/dialogmote", () => {
-    return HttpResponse.json([createInnkallingsBrev()]);
+    return HttpResponse.json([
+      createInnkallingsBrev({ createdAt: leggTilDagerPaDato(new Date(), -10).toISOString() }),
+      createAvlysningsBrev({ createdAt: leggTilDagerPaDato(new Date(), -6).toISOString() }),
+      createInnkallingsBrev({ createdAt: leggTilDagerPaDato(new Date(), -5).toISOString() }),
+      // createReferatBrev({ createdAt: leggTilDagerPaDato(new Date(), -4).toISOString() }),
+      createReferatEndretBrev({ createdAt: leggTilDagerPaDato(new Date(), -103).toISOString() }),
+    ]);
   }),
   http.get("api/motebehov", () => {
     return HttpResponse.json(motebehovUtenSvar);

--- a/src/mocks/handlers.ts
+++ b/src/mocks/handlers.ts
@@ -14,7 +14,8 @@ export const handlers = [
       createInnkallingsBrev({ createdAt: leggTilDagerPaDato(new Date(), -10).toISOString() }),
       createAvlysningsBrev({ createdAt: leggTilDagerPaDato(new Date(), -6).toISOString() }),
       createInnkallingsBrev({ createdAt: leggTilDagerPaDato(new Date(), -5).toISOString() }),
-      // createReferatBrev({ createdAt: leggTilDagerPaDato(new Date(), -4).toISOString() }),
+      createReferatBrev({ createdAt: leggTilDagerPaDato(new Date(), -4).toISOString() }),
+      createInnkallingsBrev({ createdAt: leggTilDagerPaDato(new Date(), -3).toISOString() }),
       createReferatEndretBrev({ createdAt: leggTilDagerPaDato(new Date(), -103).toISOString() }),
     ]);
   }),


### PR DESCRIPTION
Når veileder sender en innkalling til første dialogmøte blir mikrofrontend synlig for den sykmeldte

Når veileder sender referat til første dialogmøte blir mikrofrontend skjult for den sykmeldte

Hvis veileder sender en ny innkalling til andre dialogmøte blir mikrofrontend igjen synlig for den sykmeldte

Dersom veileder endrer referat til det første dialogmøtet blir mikrofrontend for det andre dialogmøte skjult for den sykmeldte. Det er ikke riktig, siden den fortsatt skal vise innkalling til det andre dialogmøtet.