### PR TITLE
Support both v3 and v4 api before switching in esyfo-proxy

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -38,7 +38,7 @@ function App() {
     motebehovResponse.data &&
     motebehovResponse.data.visMotebehov === true &&
     motebehovResponse.data.skjemaType === "SVAR_BEHOV" &&
-    motebehovResponse.data.motebehov === null
+    (motebehovResponse.data.motebehov === null || motebehovResponse.data.motebehovWithFormValues === null)
   ) {
     return <MotebehovPanel />;
   }

--- a/src/mocks/fixtures/dialogmote/ingenMotebehov.ts
+++ b/src/mocks/fixtures/dialogmote/ingenMotebehov.ts
@@ -2,6 +2,6 @@ import { MotebehovDTO } from "../../../schema/motebehovSchema";
 
 export const ingenMotebehov: MotebehovDTO = {
   visMotebehov: false,
-  motebehov: null,
-  skjemaType: null,
+  motebehovWithFormValues: null,
+  skjemaType: "MELD_BEHOV",
 };

--- a/src/mocks/fixtures/dialogmote/motebehovMedSvar.ts
+++ b/src/mocks/fixtures/dialogmote/motebehovMedSvar.ts
@@ -3,20 +3,5 @@ import { MotebehovDTO } from "../../../schema/motebehovSchema";
 export const motebehovMedSvar: MotebehovDTO = {
   visMotebehov: true,
   skjemaType: "SVAR_BEHOV",
-  motebehov: {
-    id: "12345",
-    opprettetDato: "2023-05-10T10:54:09.204Z",
-    aktorId: "1234",
-    opprettetAv: "Navn",
-    arbeidstakerFnr: "999888777",
-    virksomhetsnummer: "907670201",
-    motebehovSvar: {
-      harMotebehov: true,
-      forklaring: "Ønsker møte",
-    },
-    tildeltEnhet: null,
-    behandletTidspunkt: null,
-    behandletVeilederIdent: null,
-    skjemaType: "SVAR_BEHOV",
-  },
+  motebehovWithFormValues: {},
 };

--- a/src/mocks/fixtures/dialogmote/motebehovUtenSvar.ts
+++ b/src/mocks/fixtures/dialogmote/motebehovUtenSvar.ts
@@ -1,3 +1,7 @@
 import { MotebehovDTO } from "../../../schema/motebehovSchema";
 
-export const motebehovUtenSvar: MotebehovDTO = { visMotebehov: true, skjemaType: "SVAR_BEHOV", motebehov: null };
+export const motebehovUtenSvar: MotebehovDTO = {
+  visMotebehov: true,
+  skjemaType: "SVAR_BEHOV",
+  motebehovWithFormValues: null,
+};

--- a/src/schema/motebehovSchema.ts
+++ b/src/schema/motebehovSchema.ts
@@ -1,32 +1,12 @@
-import { union, object, literal, boolean, string, z } from "zod";
+import { union, object, literal, boolean, unknown, z } from "zod";
 
 const skjemaType = union([literal("MELD_BEHOV"), literal("SVAR_BEHOV")]);
 
-const motebehovSvar = object({
-  harMotebehov: boolean(),
-  forklaring: string().nullable(),
-});
-
-const motebehov = object({
-  id: string(),
-  opprettetDato: string(),
-  aktorId: string(),
-  opprettetAv: string().nullable(),
-  arbeidstakerFnr: string(),
-  virksomhetsnummer: string(),
-  motebehovSvar: motebehovSvar,
-  tildeltEnhet: string().nullable(),
-  behandletTidspunkt: string().nullable(),
-  behandletVeilederIdent: string().nullable(),
-  skjemaType: skjemaType.nullable(),
-});
-
 export const motebehovSchema = object({
   visMotebehov: boolean(),
-  skjemaType: skjemaType.nullable(),
-  motebehov: motebehov.nullable(),
+  skjemaType: skjemaType,
+  motebehov: unknown().nullish(),
+  motebehovWithFormValues: unknown().nullish(),
 });
 
 export type MotebehovDTO = z.infer<typeof motebehovSchema>;
-export type MotebehovDataDTO = z.infer<typeof motebehov>;
-export type MotebehovSkjemaTypeDTO = z.infer<typeof skjemaType>;


### PR DESCRIPTION
### Forklaring av endringer i zod-skjema:
- `skjemaType` er ikke lenger nullable
- nytt v4-endepunkt har annet navn på "motebehov-feltet", fra `motebehov` til `motebehovWithFormValues`. Endringen gjør at begge formater støttes.
- Denne appen trenger ikke vite om innholdet i motebehov / motebehovWithFormValues, derfor `unknown`.

### Migrasjonsplan for å bruke v4 motebehov-endepunkt i esyfo-proxy og dialogmote-mikrofrontend:
1. Endre dialogmote-mikrofrontend til å støtte begge formater (denne PR)
2. Endre esyfo-proxy til å gå over til å rute til v4-endepunkt (https://github.com/navikt/esyfo-proxy/pull/667)
3. Endre dialogmote-mikrofrontend til å kun støtte v4-endepunkt
4. (Fjerne v3-endepunkter i syfomotebehov)
