### PR TITLE
Simplify and correct motebehov schema

### DIFF
--- a/cypress/utils/mountWithMocks.tsx
+++ b/cypress/utils/mountWithMocks.tsx
@@ -1,12 +1,12 @@
 import { mount } from "cypress/react18";
 import { SWRConfig } from "swr";
-import { MotebehovDTO } from "../../src/schema/motebehovSchema";
+import { MotebehovStatusDTO } from "../../src/schema/motebehovSchema";
 import { ingenMotebehov } from "../../src/mocks/fixtures/dialogmote/ingenMotebehov";
 import { BrevDTO } from "../../src/schema/brevSchema";
 
 export interface StubResponses {
   dialogmoteResponse?: BrevDTO[];
-  motebehovResponse?: MotebehovDTO;
+  motebehovResponse?: MotebehovStatusDTO;
 }
 
 export const mountWithStubs = (componentUnderTest: JSX.Element, stubResponses: StubResponses) => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,13 @@ import { isdialogmoteApiUrl, syfomotebehovApiUrl } from "./api/urls";
 import { Fetcher } from "swr";
 import React from "react";
 import { MotebehovPanel } from "./components/panels/motebehov/MotebehovPanel";
-import { MotebehovDTO } from "./schema/motebehovSchema";
+import { MotebehovStatusDTO } from "./schema/motebehovSchema";
 import { BrevDTO } from "./schema/brevSchema";
 import { DialogmotePanel } from "./components/panels/moteinnkalling/DialogmotePanel";
 
 function App() {
   const fetchBrev: Fetcher<BrevDTO[], string> = (path) => get(path);
-  const fetchMotebehov: Fetcher<MotebehovDTO, string> = (path) => get(path);
+  const fetchMotebehov: Fetcher<MotebehovStatusDTO, string> = (path) => get(path);
   const dialogmoteResponse = useSWRImmutable(isdialogmoteApiUrl, fetchBrev);
   const motebehovResponse = useSWRImmutable(syfomotebehovApiUrl, fetchMotebehov);
 

--- a/src/mocks/fixtures/dialogmote/ingenMotebehov.ts
+++ b/src/mocks/fixtures/dialogmote/ingenMotebehov.ts
@@ -1,7 +1,7 @@
-import { MotebehovDTO } from "../../../schema/motebehovSchema";
+import { MotebehovStatusDTO } from "../../../schema/motebehovSchema";
 
-export const ingenMotebehov: MotebehovDTO = {
+export const ingenMotebehov: MotebehovStatusDTO = {
   visMotebehov: false,
   motebehov: null,
-  skjemaType: null,
+  skjemaType: "MELD_BEHOV",
 };

--- a/src/mocks/fixtures/dialogmote/motebehovMedSvar.ts
+++ b/src/mocks/fixtures/dialogmote/motebehovMedSvar.ts
@@ -1,22 +1,9 @@
-import { MotebehovDTO } from "../../../schema/motebehovSchema";
+import { MotebehovStatusDTO } from "../../../schema/motebehovSchema";
 
-export const motebehovMedSvar: MotebehovDTO = {
+export const motebehovMedSvar: MotebehovStatusDTO = {
   visMotebehov: true,
   skjemaType: "SVAR_BEHOV",
   motebehov: {
     id: "12345",
-    opprettetDato: "2023-05-10T10:54:09.204Z",
-    aktorId: "1234",
-    opprettetAv: "Navn",
-    arbeidstakerFnr: "999888777",
-    virksomhetsnummer: "907670201",
-    motebehovSvar: {
-      harMotebehov: true,
-      forklaring: "Ønsker møte",
-    },
-    tildeltEnhet: null,
-    behandletTidspunkt: null,
-    behandletVeilederIdent: null,
-    skjemaType: "SVAR_BEHOV",
   },
 };

--- a/src/mocks/fixtures/dialogmote/motebehovUtenSvar.ts
+++ b/src/mocks/fixtures/dialogmote/motebehovUtenSvar.ts
@@ -1,3 +1,7 @@
-import { MotebehovDTO } from "../../../schema/motebehovSchema";
+import { MotebehovStatusDTO } from "../../../schema/motebehovSchema";
 
-export const motebehovUtenSvar: MotebehovDTO = { visMotebehov: true, skjemaType: "SVAR_BEHOV", motebehov: null };
+export const motebehovUtenSvar: MotebehovStatusDTO = {
+  visMotebehov: true,
+  skjemaType: "SVAR_BEHOV",
+  motebehov: null,
+};

--- a/src/schema/motebehovSchema.ts
+++ b/src/schema/motebehovSchema.ts
@@ -1,32 +1,16 @@
-import { union, object, literal, boolean, string, z } from "zod";
+import { union, object, literal, boolean, z, string } from "zod";
 
 const skjemaType = union([literal("MELD_BEHOV"), literal("SVAR_BEHOV")]);
 
-const motebehovSvar = object({
-  harMotebehov: boolean(),
-  forklaring: string().nullable(),
-});
-
 const motebehov = object({
   id: string(),
-  opprettetDato: string(),
-  aktorId: string(),
-  opprettetAv: string().nullable(),
-  arbeidstakerFnr: string(),
-  virksomhetsnummer: string(),
-  motebehovSvar: motebehovSvar,
-  tildeltEnhet: string().nullable(),
-  behandletTidspunkt: string().nullable(),
-  behandletVeilederIdent: string().nullable(),
-  skjemaType: skjemaType.nullable(),
+  // This app doesn't need to know more about motebehov.
 });
 
-export const motebehovSchema = object({
+export const motebehovStatusSchema = object({
   visMotebehov: boolean(),
-  skjemaType: skjemaType.nullable(),
+  skjemaType: skjemaType,
   motebehov: motebehov.nullable(),
 });
 
-export type MotebehovDTO = z.infer<typeof motebehovSchema>;
-export type MotebehovDataDTO = z.infer<typeof motebehov>;
-export type MotebehovSkjemaTypeDTO = z.infer<typeof skjemaType>;
+export type MotebehovStatusDTO = z.infer<typeof motebehovStatusSchema>;


### PR DESCRIPTION
Remove unneccessary schema details.
Rename MotebehovDTO to MotebehovStatusDTO.
skjemaType is no longer nullable.